### PR TITLE
Remove sel-screen time from timestamps

### DIFF
--- a/src/zcl_timem_gui.clas.abap
+++ b/src/zcl_timem_gui.clas.abap
@@ -18,7 +18,9 @@ CLASS zcl_timem_gui DEFINITION
 
     METHODS revert
       IMPORTING
-        ts TYPE timestamp.
+        ts TYPE timestamp
+      RAISING
+        zcx_timem.
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/zcl_timem_gui_handler.clas.abap
+++ b/src/zcl_timem_gui_handler.clas.abap
@@ -47,6 +47,10 @@ CLASS zcl_timem_gui_handler DEFINITION
       EXPORTING
         e_type        TYPE versobjtyp
         e_object_name TYPE versobjnam.
+
+    METHODS revert
+      IMPORTING
+        ts TYPE timestamp.
 ENDCLASS.
 
 
@@ -168,9 +172,9 @@ CLASS ZCL_TIMEM_GUI_HANDLER IMPLEMENTATION.
       WHEN 'revert'.
         " Revert to the requested timestmap
         ts = CONV #( getdata+7 ).
-        gui->revert( ts ).
+        revert( ts ).
         " And then display the new present time
-        get time stamp field ts.
+        GET TIME STAMP FIELD ts.
         zcl_timem_options=>get_instance( )->set( timestamp = ts ).
         display_version( ).
 
@@ -195,5 +199,15 @@ CLASS ZCL_TIMEM_GUI_HANDLER IMPLEMENTATION.
           action  = action
           getdata = getdata ).
     ENDCASE.
+  ENDMETHOD.
+
+
+  METHOD revert.
+    TRY.
+        gui->revert( ts ).
+      CATCH zcx_timem INTO DATA(exc).
+        DATA(text) = exc->get_text( ).
+        MESSAGE text TYPE 'E'.
+    ENDTRY.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_timem_parts.clas.abap
+++ b/src/zcl_timem_parts.clas.abap
@@ -25,7 +25,9 @@ CLASS zcl_timem_parts DEFINITION
 
     METHODS revert
       IMPORTING
-        ts TYPE timestamp.
+        ts TYPE timestamp
+      RAISING
+        zcx_timem.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -132,9 +134,6 @@ CLASS ZCL_TIMEM_PARTS IMPLEMENTATION.
         COLLECT ts INTO result.
       ENDLOOP.
     ENDLOOP.
-    " We also need the user selected timestamp
-    DATA(options_timestamp) = options->timestamp.
-    COLLECT options_timestamp INTO result.
     SORT result BY table_line DESCENDING.
   ENDMETHOD.
 


### PR DESCRIPTION
Somehow I thought I needed it there but it really doesn't make sense.

Also, solving a ZCX_TIMEM which wasn't being caught.

Partially solves #98.