### PR TITLE
Update zcl_timem_request.clas.abap

### DIFF
--- a/src/zcl_timem_request.clas.abap
+++ b/src/zcl_timem_request.clas.abap
@@ -85,7 +85,7 @@ CLASS ZCL_TIMEM_REQUEST IMPLEMENTATION.
     FROM e070
     LEFT JOIN e07t ON e07t~trkorr = e070~trkorr
     WHERE e070~trkorr = @id
-      AND langu  = 'E'
+      AND langu  = @sy-langu
     ORDER BY as4text, trstatus.
       EXIT.
     ENDSELECT.


### PR DESCRIPTION
A possible solution for non english systems.
Reading texts from e07t with sy-langu instead of E.