### PR TITLE
Ignore language getting request description

### DIFF
--- a/src/zcl_timem_request.clas.abap
+++ b/src/zcl_timem_request.clas.abap
@@ -85,7 +85,6 @@ CLASS ZCL_TIMEM_REQUEST IMPLEMENTATION.
     FROM e070
     LEFT JOIN e07t ON e07t~trkorr = e070~trkorr
     WHERE e070~trkorr = @id
-      AND langu  = 'E'
     ORDER BY as4text, trstatus.
       EXIT.
     ENDSELECT.


### PR DESCRIPTION
English was hard coded. But because in non-english systems this would not work, and because worbench orders will only have one record anyway, I will ignore the language. Hopefully this will be ok.

Closes #111.