### PR TITLE
Fixed issue #135 creating a Z type similar to the standard one

### DIFF
--- a/src/zcl_timem_object_fugr.clas.abap
+++ b/src/zcl_timem_object_fugr.clas.abap
@@ -24,7 +24,7 @@ CLASS zcl_timem_object_fugr DEFINITION
         VALUE(result) TYPE program .
     METHODS get_functions
       RETURNING
-        VALUE(result) TYPE re_t_funcincl .
+        VALUE(result) TYPE zre_t_funcincl .
 ENDCLASS.
 
 

--- a/src/zre_t_funcincl.ttyp.xml
+++ b/src/zre_t_funcincl.ttyp.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_TTYP" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD40V>
+    <TYPENAME>ZRE_T_FUNCINCL</TYPENAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <ROWTYPE>RS38L_INCL</ROWTYPE>
+    <ROWKIND>S</ROWKIND>
+    <DATATYPE>STRU</DATATYPE>
+    <ACCESSMODE>T</ACCESSMODE>
+    <KEYDEF>D</KEYDEF>
+    <KEYKIND>N</KEYKIND>
+    <DDTEXT>Nome do módulo de função e include</DDTEXT>
+   </DD40V>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
I tried to fix the issue  #135 by copying the re_t_funcincl type to a Z one. The re_t_funcincl is not available on NW 7.52.